### PR TITLE
#23 の修正。フロントエンドに表示されるタイムゾーンがおかしい

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -1,6 +1,6 @@
 # global settings
 FETCH_INTERVAL_SEC=1 # twitcasting API fetch interval (sec)
-TZ="Asia/Tokyo"
+TZ="UTC"
 YOUR_SERVER_IP_OR_FQDN="__YOUR_SERVER_IP_OR_FQDN__"
 #LOG_LEVEL=debug # if you want to see debug logs, uncomment this line.
 

--- a/manage-frontend/twitcasting-manager/app/page.tsx
+++ b/manage-frontend/twitcasting-manager/app/page.tsx
@@ -117,18 +117,7 @@ export default function StreamerList() {
                 </h2>
 
                 <p className="text-sm text-muted-foreground">
-                  {(() => {
-                  const raw = streamer.action_date_time
-                  // Convert "2025-02-12 08:47:59.284681" to "2025-02-12T08:47:59.284681"
-                  const parsed = new Date(raw.replace(" ", "T"))
-                  const y = parsed.getFullYear()
-                  const m = parsed.getMonth() + 1
-                  const d = parsed.getDate()
-                  const hh = parsed.getHours()
-                  const mm = parsed.getMinutes()
-                  const ss = parsed.getSeconds()
-                  return `追加日: ${y}/${m}/${d} ${hh}:${mm}:${ss}`
-                  })()}
+                  追加日: {new Date(streamer.action_date_time).toLocaleString(navigator.language)}
                 </p>
                 <p className="text-sm text-muted-foreground">状態: {streamer.recording_state ? "配信録画中" : "配信オフライン"}</p>
               </div>

--- a/manage-frontend/twitcasting-manager/app/page.tsx
+++ b/manage-frontend/twitcasting-manager/app/page.tsx
@@ -117,7 +117,7 @@ export default function StreamerList() {
                 </h2>
 
                 <p className="text-sm text-muted-foreground">
-                  追加日: {new Date(streamer.action_date_time).toLocaleString()}
+                  追加日: {new Date(streamer.action_date_time).toLocaleString(undefined, { timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone })}
                 </p>
                 <p className="text-sm text-muted-foreground">状態: {streamer.recording_state ? "配信録画中" : "配信オフライン"}</p>
               </div>

--- a/manage-frontend/twitcasting-manager/app/page.tsx
+++ b/manage-frontend/twitcasting-manager/app/page.tsx
@@ -117,7 +117,7 @@ export default function StreamerList() {
                 </h2>
 
                 <p className="text-sm text-muted-foreground">
-                  追加日: {new Date(streamer.action_date_time).toLocaleString(undefined, { timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone })}
+                  追加日: {new Date(streamer.action_date_time).toLocaleString(navigator.language)}
                 </p>
                 <p className="text-sm text-muted-foreground">状態: {streamer.recording_state ? "配信録画中" : "配信オフライン"}</p>
               </div>

--- a/manage-frontend/twitcasting-manager/app/page.tsx
+++ b/manage-frontend/twitcasting-manager/app/page.tsx
@@ -117,7 +117,7 @@ export default function StreamerList() {
                 </h2>
 
                 <p className="text-sm text-muted-foreground">
-                  追加日: {new Date(streamer.action_date_time).toLocaleString(navigator.language)}
+                  追加日: {new Date(streamer.action_date_time).toLocaleString(window.navigator.language)}
                 </p>
                 <p className="text-sm text-muted-foreground">状態: {streamer.recording_state ? "配信録画中" : "配信オフライン"}</p>
               </div>

--- a/manage-frontend/twitcasting-manager/app/page.tsx
+++ b/manage-frontend/twitcasting-manager/app/page.tsx
@@ -117,7 +117,18 @@ export default function StreamerList() {
                 </h2>
 
                 <p className="text-sm text-muted-foreground">
-                  追加日: {new Date(streamer.action_date_time).toLocaleString(navigator.language)}
+                  {(() => {
+                  const raw = streamer.action_date_time
+                  // Convert "2025-02-12 08:47:59.284681" to "2025-02-12T08:47:59.284681"
+                  const parsed = new Date(raw.replace(" ", "T"))
+                  const y = parsed.getFullYear()
+                  const m = parsed.getMonth() + 1
+                  const d = parsed.getDate()
+                  const hh = parsed.getHours()
+                  const mm = parsed.getMinutes()
+                  const ss = parsed.getSeconds()
+                  return `追加日: ${y}/${m}/${d} ${hh}:${mm}:${ss}`
+                  })()}
                 </p>
                 <p className="text-sm text-muted-foreground">状態: {streamer.recording_state ? "配信録画中" : "配信オフライン"}</p>
               </div>


### PR DESCRIPTION
# About

#23 の修正。

.env_sampleでbackendにてTZ="Asia/Tokyo"を指定してしまっていたため。